### PR TITLE
Removed unnecessary type cast

### DIFF
--- a/notes/thread/ops.c
+++ b/notes/thread/ops.c
@@ -16,7 +16,6 @@ void *product(void *input) {
 void *sum(void *input) {
   int i, s=0; 
   int *array = input;
-  array = (int *) array;
   for (i=array[0]; i<=array[1]; i++)
     s += i;
   array[2] = s;


### PR DESCRIPTION
Since array is already of type int \* it is useless to cast it back to int *.
